### PR TITLE
belongs_to :foobar, :dependent => :destroy

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -161,7 +161,7 @@ module PermanentRecords
               deleted_at + 3.seconds
             ]
           )
-        elsif cardinality == 'one'
+        elsif cardinality == 'one' or cardinality == 'belongs_to'
           if active_record_3?
             self.class.unscoped do
               records = [] << send(name)

--- a/test/dirt.rb
+++ b/test/dirt.rb
@@ -1,0 +1,3 @@
+class Dirt < ActiveRecord::Base
+  has_one :hole
+end

--- a/test/hole.rb
+++ b/test/hole.rb
@@ -1,4 +1,7 @@
 class Hole < ActiveRecord::Base
+  # Because when we're destroying a mole hole we're obviously using high explosives.
+  belongs_to :dirt, :dependent => :destroy
+  
   # muskrats are permanent
   has_many :muskrats, :dependent => :destroy
   # moles are not permanent

--- a/test/permanent_records_test.rb
+++ b/test/permanent_records_test.rb
@@ -5,7 +5,7 @@
 
 require File.expand_path(File.dirname(__FILE__) + "/test_helper")
 
-%w(hole mole muskrat kitty location comment difficulty unused_model).each do |a|
+%w(dirt hole mole muskrat kitty location comment difficulty unused_model).each do |a|
   require File.expand_path(File.dirname(__FILE__) + "/" + a)
 end
 
@@ -19,7 +19,8 @@ class PermanentRecordsTest < ActiveSupport::TestCase
     @the_girl   = Muskrat.create!(:name => 'Dot')
     Kitty.delete_all
     @kitty = Kitty.create!(:name => 'Meow Meow')
-    @hole = Hole.create(:number => 14)
+    @dirt = Dirt.create!(:color => 'Brown')
+    @hole = Hole.create(:number => 14, :dirt => @dirt)
     @hole.muskrats.create(:name => "Active Muskrat")
     @hole.muskrats.create(:name => "Deleted Muskrat", :deleted_at => 5.days.ago)
     Location.delete_all
@@ -157,9 +158,11 @@ class PermanentRecordsTest < ActiveSupport::TestCase
   def test_dependent_permanent_records_with_has_many_cardinality_should_be_revived_when_parent_is_revived
     assert @hole.is_permanent?
     @hole.destroy
+    assert @dirt.deleted?
     assert @hole.muskrats.find_by_name("Active Muskrat").deleted?
     @hole.revive
     assert !@hole.muskrats.find_by_name("Active Muskrat").deleted?
+    assert !@dirt.deleted?
   end
   
   def test_dependent_permanent_records_with_has_one_cardinality_should_be_revived_when_parent_is_revived

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -12,6 +12,7 @@ ActiveRecord::Schema.define(:version => 1) do
 
   create_table :holes, :force => true do |t|
     t.integer :number
+    t.references :dirt
     t.datetime :deleted_at
   end
   
@@ -41,6 +42,11 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :unused_models, :force => true do |t|
     t.string :name
     t.references :hole
+    t.datetime :deleted_at
+  end
+
+  create_table :dirts, :force => true do |t|
+    t.string :color
     t.datetime :deleted_at
   end
 


### PR DESCRIPTION
So I'm working with an app with a belongs_to with a :dependent => :destroy. Yeah, I know. :)

records on permanent_records.rb#173 was nil, so I added belongs_to as a cardinality, and fabbed up a test!

So far working well in our app, but we haven't hit production with it yet.
