### PR TITLE
Change to public run_callbacks API

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -29,7 +29,7 @@ module PermanentRecords
     end
 
     def revive
-      _run_revive_callbacks { set_deleted_at nil }
+      run_callbacks(:revive) { set_deleted_at nil }
       self
     end
 
@@ -65,7 +65,7 @@ module PermanentRecords
     end
 
     def destroy_with_permanent_records(force = nil)
-      _run_destroy_callbacks do
+      run_callbacks(:destroy) do
         deleted? || new_record? ? save : set_deleted_at(Time.now, force)
       end
       self


### PR DESCRIPTION
Hi!

It seems the `_run_destroy_callbacks` method is no longer present in Rails 4 (and potentially earlier versions as well). It's advised to always run the public API methods in the Rails API when doing things like this (in this case `run_callbacks(:*)`), so I changed the implementation in use in this gem.

This should also fix issue #25.

All tests are green locally for me except `PermanentRecords#destroy with dependent records as default scope with :has_many cardinality comments.size` in `spec/permanent_records_spec.rb:119` - that one was broken before I changed any code, however, so it's probably something else causing that.
