### PR TITLE
use arel instead of plain SQL

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -163,11 +163,11 @@ module PermanentRecords
 
   module Scopes
     def deleted
-      where "#{table_name}.deleted_at IS NOT NULL"
+      where arel_table[:deleted_at].not_eq(nil)
     end
 
     def not_deleted
-      where "#{table_name}.deleted_at IS NULL"
+      where arel_table[:deleted_at].eq(nil)
     end
   end
 


### PR DESCRIPTION
Hi!

sample code:

``` ruby
Design.where(enabled: false).deleted.where_values.reduce(:or).to_sql
```

expected:

``` ruby
#=> "(`designs`.`enabled` = 0 OR `designs`.`deleted_at` IS NOT NULL)"
```

actual:

``` ruby
#=> "(`designs`.`enabled` = 0 OR 'designs.deleted_at IS NOT NULL')"
```

reason:
# deleted / #not_deleted are implemented using plain SQL.

solution:
fix #deleted / #not_deleted using arel.
