### PR TITLE
revive(validate: false) is enabled.

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -28,8 +28,8 @@ module PermanentRecords
       deleted_at if is_permanent?
     end
 
-    def revive
-      run_callbacks(:revive) { set_deleted_at nil }
+    def revive(validate = nil)
+      run_callbacks(:revive) { set_deleted_at(nil, validate) }
       self
     end
 

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -135,8 +135,9 @@ describe PermanentRecords do
   describe '#revive' do
 
     let!(:record) { hole.destroy }
+    let(:should_validate) { nil  }
 
-    subject { record.revive }
+    subject { record.revive should_validate }
 
     it 'returns the record' do
       subject.should == record
@@ -158,6 +159,16 @@ describe PermanentRecords do
       }
       it 'raises' do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      context 'with validation opt-out' do
+        let(:should_validate) {{ validate: false }}
+        it 'doesnt raise' do
+          expect { subject }.to_not raise_error
+        end
+        it 'makes deleted? return false' do
+          subject.should_not be_deleted
+        end
       end
     end
 


### PR DESCRIPTION
Since it is possible to call `.destroy(validate: false)`, it think it makes sense to enable `.revive(validate: false)` too.

This use case is obvious for records that are soft-deleted by `.destroy(validate: false)` and to be revived later.
