### PR TITLE
Fix handling of serialized attributes

### DIFF
--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -37,6 +37,11 @@ describe PermanentRecords do
       expect { subject }.to_not change { record.class.count }
     end
 
+    it 'handles serialized attributes correctly' do
+      expect { subject.options }.to_not raise_error
+      expect { subject.size }.to_not raise_error if record.respond_to?(:size)
+    end
+
     context 'with force argument set to truthy' do
       let(:should_force) { :force }
 

--- a/spec/support/hole.rb
+++ b/spec/support/hole.rb
@@ -11,4 +11,7 @@ class Hole < ActiveRecord::Base
   has_one :unused_model, :dependent => :destroy
   has_one :difficulty, :dependent => :destroy
   has_many :comments, :dependent => :destroy
+
+  serialize :options, Hash
+  store :properties, :accessors => [:size] if respond_to?(:store)
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -12,6 +12,8 @@ ActiveRecord::Schema.define(:version => 1) do
 
   create_table :holes, :force => true do |t|
     t.integer :number
+    t.text :options
+    t.text :properties
     t.references :dirt
     t.datetime :deleted_at
   end


### PR DESCRIPTION
A serialized attribute value in @attributes is actually wrapped in
another class since AR 3.2.0. This was not respected during deletion.

Fixes "undefined method `unserialized_value'" after deleting a
permanent record and then trying to access a serialized attribute
on the same model instance.

I'm only half happy with this solution (manually re-wrapping the attributes), 
so if you can think of something better... ;)
