### PR TITLE
Remove Rails 4 deprecation warnings

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -89,9 +89,8 @@ module PermanentRecords
       end.each do |name, reflection|
         cardinality = reflection.macro.to_s.gsub('has_', '')
         if cardinality == 'many'
-          records = send(name).unscoped.find(
-            :all,
-            :conditions => [
+          records = send(name).unscoped.where(
+            [
               "#{reflection.quoted_table_name}.deleted_at > ?" +
               " AND " +
               "#{reflection.quoted_table_name}.deleted_at < ?",

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -120,7 +120,7 @@ describe PermanentRecords do
         end
       end
       context 'as default scope' do
-        let(:load_comments) { Comment.unscoped.find_all_by_hole_id(subject.id) }
+        let(:load_comments) { Comment.unscoped.where(:hole_id => subject.id) }
         context 'with :has_many cardinality' do
           before {
             load_comments.size.should == 2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ module Rails
   def self.env; 'test'end
 end
 
+I18n.config.enforce_available_locales = true
+
 require 'logger'
 ActiveRecord::Base.logger = Logger.new support.join("debug.log")
 ActiveRecord::Base.configurations = YAML::load_file support.join('database.yml')

--- a/spec/support/comment.rb
+++ b/spec/support/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ActiveRecord::Base
   belongs_to :hole
 
-  default_scope where(:deleted_at => nil)
+  default_scope { where(:deleted_at => nil) }
 end

--- a/spec/support/difficulty.rb
+++ b/spec/support/difficulty.rb
@@ -1,5 +1,5 @@
 class Difficulty < ActiveRecord::Base
   belongs_to :hole
 
-  default_scope where(:deleted_at => nil)
+  default_scope { where(:deleted_at => nil) }
 end


### PR DESCRIPTION
Tests of ActiveRecord models that implement this gem issue warnings in a Rails 4 environment:

```
DEPRECATION WARNING: Calling #find(:all) is deprecated. Please call #all directly instead. You have also used finder options. These are also deprecated. Please build a scope instead of using finder options.
```

This branch also removes deprecation warnings that result when running the gem's test suite as well.
