### PR TITLE
Update revive_destroyed_dependent_records

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -89,9 +89,8 @@ module PermanentRecords
       end.each do |name, reflection|
         cardinality = reflection.macro.to_s.gsub('has_', '')
         if cardinality == 'many'
-          records = send(name).unscoped.find(
-            :all,
-            :conditions => [
+          records = send(name).unscoped.where(
+            [
               "#{reflection.quoted_table_name}.deleted_at > ?" +
               " AND " +
               "#{reflection.quoted_table_name}.deleted_at < ?",


### PR DESCRIPTION
Use where instead of deprecated method, since Rails 3.2, find(:all, :conditions => {}).

Old/deprecated method resulted in the following error with Rails 4+ and Postgres when trying to revive a deleted object with dependent associations:
ActiveRecord::StatementInvalid: PG::InvalidTextRepresentation: ERROR:  invalid input syntax for integer: "all"
