### PR TITLE
Make `deleted?` return an appropriate value for regular models.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ group :test do
   gem 'pry'
   gem 'awesome_print'
   gem 'database_cleaner'
-  gem 'rspec'
+  gem 'rspec', '~> 2.14'
 end

--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -25,7 +25,11 @@ module PermanentRecords
     end
 
     def deleted?
-      deleted_at if is_permanent?
+      if is_permanent?
+        !!deleted_at
+      else
+        destroyed?
+      end
     end
 
     def revive(validate = nil)

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -84,6 +84,10 @@ describe PermanentRecords do
       it 'really removes the record' do
         expect { subject }.to change { record.class.count }.by(-1)
       end
+
+      it 'makes deleted? return true' do
+        subject.should be_deleted
+      end
     end
 
     context 'with dependent records' do


### PR DESCRIPTION
It sucks having to rely on different interfaces based on wether the record has a deleted_at column.

Currently, if the record has no deleted_at column, `deleted?` will return nil, even if the record is destroyed. With this change `deleted?` always returns an appropriate value so that consumers of the method need not care if it's a permanent record or not.