### PR TITLE
Fix attributes handling for activerecord 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.0.0
   - 1.9.3
-  - 1.9.2
 env:
   - AR_TEST_VERSION: 3.0.0
   - AR_TEST_VERSION: 3.2.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
 env:
   - AR_TEST_VERSION: 3.0.0
   - AR_TEST_VERSION: 3.2.12
+  - AR_TEST_VERSION: 4.0.0
+  - AR_TEST_VERSION: 4.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ group :test do
   gem 'pry'
   gem 'awesome_print'
   gem 'database_cleaner'
-  gem 'rspec'
+  gem 'rspec', '~> 2.14.1'
 end


### PR DESCRIPTION
Currently all tests fail when running with AR 4.2.0. With this change, all tests are green between AR 3.0 to 4.2. Would be great if someone could review!

Details: As far as I see the problem is the change in AR's internal attribute handling/caching: There is no @attributes_cache any more and @attributes is now an AttributeSet (which is not returned by the attributes method).
