### PR TITLE
Fix accessing serialized attributes after destroy/revive (rails 4.0)

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -60,16 +60,15 @@ module PermanentRecords
           record.save!
         end
         if ::Gem::Version.new(::ActiveRecord::VERSION::STRING) < ::Gem::Version.new('4.2.0')
-          @attributes, @attributes_cache = record.attributes, record.attributes
+          @attributes = record.attributes
+          @attributes_cache = record.attributes.except(record.class.serialized_attributes.keys)
           # workaround for active_record >= 3.2.0: re-wrap values of serialized attributes
           # (record.attributes returns the plain values but in the instance variables they are expected to be wrapped)
           if defined?(::ActiveRecord::AttributeMethods::Serialization::Attribute)
             serialized_attribute_class = ::ActiveRecord::AttributeMethods::Serialization::Attribute
             self.class.serialized_attributes.each do |key, coder|
               if @attributes.key?(key)
-                attr = serialized_attribute_class.new(coder, @attributes[key], :unserialized)
-                @attributes[key] = attr
-                @attributes_cache[key] = attr
+                @attributes[key] = serialized_attribute_class.new(coder, @attributes[key], :unserialized)
               end
             end
           end

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -5,7 +5,7 @@ describe PermanentRecords do
   let!(:frozen_moment) { Time.now                            }
   let!(:dirt)          { Dirt.create!                        }
   let!(:earthworm)     { dirt.create_earthworm               }
-  let!(:hole)          { dirt.create_hole                    }
+  let!(:hole)          { dirt.create_hole(:options => {})    }
   let!(:muskrat)       { hole.muskrats.create!               }
   let!(:mole)          { hole.moles.create!                  }
   let!(:location)      { hole.create_location                }
@@ -38,8 +38,8 @@ describe PermanentRecords do
     end
 
     it 'handles serialized attributes correctly' do
-      expect { subject.options }.to_not raise_error
-      expect { subject.size }.to_not raise_error if record.respond_to?(:size)
+      expect(subject.options).to eq({})
+      expect(subject.size).to be_nil if record.respond_to?(:size)
     end
 
     context 'with force argument set to truthy' do


### PR DESCRIPTION
Don't cache serialized attributes

Without this fix, when a serialized attribute is accessed after destroy
or revive, the Serialization::Attribute wrapper is returned instead of
the actual value (rails 4.0/4.1).

@JackDanger Review/merge and patch version release would be greatly appreciated! ;) Thanks!