### PR TITLE
Transaction for destroy / revive, drop Rails 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.0.0
   - 1.9.3
 env:
-  - AR_TEST_VERSION: 3.0.0
+  - AR_TEST_VERSION: 3.1.0
   - AR_TEST_VERSION: 3.2.12
   - AR_TEST_VERSION: 4.0.0
   - AR_TEST_VERSION: 4.2.0

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# PermanentRecords (Rails 3+)
+# PermanentRecords (Rails 3.1+)
 
 [http://github.com/JackDanger/permanent_records/](http://github.com/JackDanger/permanent_records/)
 
@@ -8,12 +8,12 @@ Any model that you've given a "deleted_at" datetime column will have that column
 ## What methods does it give me?
 
 ```ruby
-User.find(3).destroy          # Sets the 'deleted_at' attribute to Time.now 
+User.find(3).destroy          # Sets the 'deleted_at' attribute to Time.now
                               # and returns a frozen record.
-                              
-User.find(3).destroy(:force)  # Executes the real destroy method, the record 
+
+User.find(3).destroy(:force)  # Executes the real destroy method, the record
                               # will be removed from the database.
-                              
+
 User.destroy_all              # Soft-deletes all User records.
 
 User.delete_all               # bye bye everything (no soft-deleting here)
@@ -53,7 +53,7 @@ end
 
 User.find(3).destroy         # All the comments are destroyed as well.
 
-User.find(3).revive          # All the comments that were just destroyed 
+User.find(3).revive          # All the comments that were just destroyed
                              # are now back in pristine condition.
 ```
 
@@ -75,7 +75,7 @@ end
 
 ## Is Everything Automated?
 
-Yes. You don't have to change ANY of your code to get permanent archiving of all your data with this gem. 
+Yes. You don't have to change ANY of your code to get permanent archiving of all your data with this gem.
 When you call `destroy` on any record  (or `destroy_all` on a class or association) your records will
 all have a deleted_at timestamp set on them.
 

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -77,7 +77,6 @@ describe PermanentRecords do
       end
     end
 
-
     context 'when model has no deleted_at column' do
       let(:record) { kitty }
 
@@ -100,10 +99,25 @@ describe PermanentRecords do
           it 'marks records as deleted' do
             subject.muskrats.each {|m| m.should be_deleted }
           end
+
+          context 'when error occurs' do
+            before { Hole.any_instance.stub(:valid?).and_return(false) }
+            it 'does not mark records as deleted' do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.muskrats.not_deleted.count).to eq(1)
+            end
+          end
+
           context 'with force delete' do
             let(:should_force) { :force }
             it('') { expect { subject }.to change { Muskrat.count }.by(-1) }
             it('') { expect { subject }.to change { Comment.count }.by(-2) }
+
+            context 'when error occurs' do
+              before { Difficulty.any_instance.stub(:destroy).and_return(false) }
+              it('') { expect { subject }.not_to change { Muskrat.count } }
+              it('') { expect { subject }.not_to change { Comment.count } }
+            end
           end
         end
 
@@ -111,18 +125,59 @@ describe PermanentRecords do
           it 'marks records as deleted' do
             subject.location.should be_deleted
           end
+
+          context 'when error occurs' do
+            before { Hole.any_instance.stub(:valid?).and_return(false) }
+            it('does not mark records as deleted') do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.location(true)).not_to be_deleted
+            end
+          end
+
           context 'with force delete' do
             let(:should_force) { :force }
             it('') { expect { subject }.to change { Muskrat.count  }.by(-1) }
             it('') { expect { subject }.to change { Location.count }.by(-1) }
+
+            context 'when error occurs' do
+              before { Difficulty.any_instance.stub(:destroy).and_return(false) }
+              it('') { expect { subject }.not_to change { Muskrat.count } }
+              it('') { expect { subject }.not_to change { Location.count } }
+            end
+          end
+        end
+
+        context 'with belongs_to cardinality' do
+          it 'marks records as deleted' do
+            subject.dirt.should be_deleted
+          end
+
+          context 'when error occurs' do
+            before { Hole.any_instance.stub(:valid?).and_return(false) }
+            it 'does not mark records as deleted' do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.dirt(true)).not_to be_deleted
+            end
+          end
+
+          context 'with force delete' do
+            let(:should_force) { :force }
+            it('') { expect { subject }.to change { Dirt.count }.by(-1) }
+
+            context 'when error occurs' do
+              before { Difficulty.any_instance.stub(:destroy).and_return(false) }
+              it('') { expect { subject }.not_to change { Dirt.count } }
+            end
           end
         end
       end
+
       context 'that are non-permanent' do
         it 'removes them' do
           expect { subject }.to change { Mole.count }.by(-1)
         end
       end
+
       context 'as default scope' do
         let(:load_comments) { Comment.unscoped.where(:hole_id => subject.id) }
         context 'with :has_many cardinality' do
@@ -205,19 +260,49 @@ describe PermanentRecords do
           it 'revives them' do
             subject.muskrats.each {|m| m.should_not be_deleted }
           end
+          context 'when error occurs' do
+            before { Hole.any_instance.stub(:valid?).and_return(false) }
+            it 'does not revive them' do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.muskrats.deleted.count).to eq(1)
+            end
+          end
         end
 
         context 'with has_one cardinality' do
           it 'revives them' do
             subject.location.should_not be_deleted
           end
+          context 'when error occurs' do
+            before { Hole.any_instance.stub(:valid?).and_return(false) }
+            it('does not mark records as deleted') do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.location(true)).to be_deleted
+            end
+          end
+        end
+
+        context 'with belongs_to cardinality' do
+          it 'revives them' do
+            subject.dirt.should_not be_deleted
+          end
+
+          context 'when error occurs' do
+            before { Hole.any_instance.stub(:valid?).and_return(false) }
+            it 'does not revive them' do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.dirt(true)).to be_deleted
+            end
+          end
         end
       end
+
       context 'that are non-permanent' do
         it 'cannot revive them' do
           expect { subject }.to_not change { Mole.count }
         end
       end
+
       context 'as default scope' do
         context 'with :has_many cardinality' do
           its('comments.size') { should == 2 }

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -186,11 +186,7 @@ describe PermanentRecords do
           }
           it 'deletes them' do
             load_comments.all?(&:deleted?).should be_true
-            # Doesn't change the default scope
-            # (in versions with non-broken default scope)
-            if ActiveRecord::VERSION::STRING > '3.0.0'
-              subject.comments.should be_blank
-            end
+            subject.comments.should be_blank
           end
         end
         context 'with :has_one cardinality' do


### PR DESCRIPTION
Wrap destroy and revive in a transaction (closes #45).

This PR also officially drops support for rails 3.0, for two reasons:

* 3.0 was not fully supported anyway (some dependent destroy tests in master pass on 3.0.0 but do not pass on 3.0.20)
* some added tests in this PR fail on all 3.0.x versions (the PR doesn't break anything on 3.0 that worked before)

IMHO supporting 3.1+ should be sufficient. What do you think?