### PR TITLE
Fail with validation of presence

### DIFF
--- a/spec/support/muskrat.rb
+++ b/spec/support/muskrat.rb
@@ -1,3 +1,4 @@
 class Muskrat < ActiveRecord::Base
   belongs_to :hole
+  validates :hole, presence: true
 end


### PR DESCRIPTION
Impossible to have `validates :hole, presence: true` in belongs models

```
 4) PermanentRecords scopes .deleted has no non-deleted records
     Failure/Error: 3.times { Muskrat.create! }
     ActiveRecord::RecordInvalid:
       Validation failed: Hole can't be blank
     # ./spec/permanent_records_spec.rb:346:in `block (4 levels) in <top (required)>'
     # ./spec/permanent_records_spec.rb:346:in `times'
     # ./spec/permanent_records_spec.rb:346:in `block (3 levels) in <top (required)>'
```