### PR TITLE
STI is impossible with dependent destroy

### DIFF
--- a/spec/support/location.rb
+++ b/spec/support/location.rb
@@ -2,4 +2,6 @@ class Location < ActiveRecord::Base
   belongs_to :hole
 
   validates_uniqueness_of :name, :scope => :deleted_at
+
+  has_many :zones, class_name: 'Location', foreign_key: 'parent_id', dependent: :destroy
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :locations, :force => true do |t|
     t.string :name
     t.references :hole
+    t.integer :parent_id
     t.datetime :deleted_at
   end
 


### PR DESCRIPTION
```
  1) PermanentRecords#revive returns the record
     Failure/Error: subject { record.revive should_validate }
     SystemStackError:
       stack level too deep
     # ./lib/permanent_records.rb:118:in `flatten'
     # ./lib/permanent_records.rb:118:in `block in revive_destroyed_dependent_records'
     # ./lib/permanent_records.rb:101:in `each'
     # ./lib/permanent_records.rb:101:in `revive_destroyed_dependent_records'
     # ./lib/permanent_records.rb:37:in `block in revive'

```