### PR TITLE
propagate validation flag on dependent records

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -15,8 +15,6 @@ module PermanentRecords
 
       base.instance_eval do
         define_model_callbacks :revive
-
-        before_revive :revive_destroyed_dependent_records
       end
     end
 
@@ -34,6 +32,7 @@ module PermanentRecords
 
     def revive(validate = nil)
       with_transaction_returning_status do
+        revive_destroyed_dependent_records(validate)
         run_callbacks(:revive) { set_deleted_at(nil, validate) }
         self
       end
@@ -51,9 +50,13 @@ module PermanentRecords
 
     private
 
+    def get_deleted_record
+      self.class.unscoped.find(id)
+    end
+
     def set_deleted_at(value, force = nil)
       return self unless is_permanent?
-      record = self.class.unscoped.find(id)
+      record = get_deleted_record
       record.deleted_at = value
       begin
         # we call save! instead of update_attribute so an ActiveRecord::RecordInvalid
@@ -95,7 +98,7 @@ module PermanentRecords
       deleted? ? self : false
     end
 
-    def revive_destroyed_dependent_records
+    def revive_destroyed_dependent_records(validate = nil)
       self.class.reflections.select do |name, reflection|
         'destroy' == reflection.options[:dependent].to_s && reflection.klass.is_permanent?
       end.each do |name, reflection|
@@ -116,7 +119,7 @@ module PermanentRecords
           end
         end
         [records].flatten.compact.each do |dependent|
-          dependent.revive
+          dependent.revive(validate)
         end
 
         # and update the reflection cache
@@ -222,4 +225,3 @@ module PermanentRecords
 end
 
 ActiveRecord::Base.send :include, PermanentRecords::ActiveRecord
-

--- a/spec/permanent_records/propagate_validation_flag_spec.rb
+++ b/spec/permanent_records/propagate_validation_flag_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe PermanentRecords do
+  let(:hole) { dirt.hole }
+  let(:dirt) { Dirt.create!.tap { |dirt| dirt.create_hole } }
+
+  before { hole.destroy }
+
+  describe '#revive' do
+
+    before do
+      expect(dirt).to receive(:get_deleted_record) { dirt }
+      expect(dirt).to receive(:save).with(validate: false)
+    end
+
+    it 'should propagate validation flag on dependent records' do
+      hole.revive(validate: false)
+    end
+  end
+end


### PR DESCRIPTION
Don't use callback internally to propagate validation flag.

I didn't dig to much on `ActiveSupport::Callback`, but I saw we can't pass arguments, but maybe I missed something, anyway this solution works and make sens to me.

Fix #58 