### PR TITLE
Revive parent firstly

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -60,7 +60,11 @@ module PermanentRecords
     end
 
     def get_deleted_record
-      self.class.unscoped.find(id)
+      if self.respond_to?(:parent_id) && self.parent_id.present? # Looking for parent on STI case
+        self.class.unscoped.find(parent_id)
+      else
+        self.class.unscoped.find(id)
+      end
     end
 
     def set_deleted_at(value, force = nil)
@@ -108,7 +112,7 @@ module PermanentRecords
     end
 
     def add_record_window(request, name, reflection)
-      request.unscoped.where(
+      send(name).unscope(where: :deleted_at).where(
         [
           "#{reflection.quoted_table_name}.deleted_at > ?" +
           " AND " +

--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -15,8 +15,6 @@ module PermanentRecords
 
       base.instance_eval do
         define_model_callbacks :revive
-
-        before_revive :revive_destroyed_dependent_records
       end
     end
 
@@ -34,6 +32,7 @@ module PermanentRecords
 
     def revive(validate = nil)
       with_transaction_returning_status do
+        revive_destroyed_dependent_records(validate)
         run_callbacks(:revive) { set_deleted_at(nil, validate) }
         self
       end
@@ -51,9 +50,13 @@ module PermanentRecords
 
     private
 
+    def get_deleted_record
+      self.class.unscoped.find(id)
+    end
+
     def set_deleted_at(value, force = nil)
       return self unless is_permanent?
-      record = self.class.unscoped.find(id)
+      record = get_deleted_record
       record.deleted_at = value
       begin
         # we call save! instead of update_attribute so an ActiveRecord::RecordInvalid
@@ -95,7 +98,7 @@ module PermanentRecords
       deleted? ? self : false
     end
 
-    def revive_destroyed_dependent_records
+    def revive_destroyed_dependent_records(validate = nil)
       self.class.reflections.select do |name, reflection|
         'destroy' == reflection.options[:dependent].to_s && reflection.klass.is_permanent?
       end.each do |name, reflection|
@@ -116,7 +119,7 @@ module PermanentRecords
           end
         end
         [records].flatten.compact.each do |dependent|
-          dependent.revive
+          dependent.revive(validate)
         end
 
         # and update the reflection cache
@@ -222,4 +225,3 @@ module PermanentRecords
 end
 
 ActiveRecord::Base.send :include, PermanentRecords::ActiveRecord
-

--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -30,10 +30,14 @@ module PermanentRecords
       end
     end
 
-    def revive(validate = nil)
+    def revive(options = nil)
       with_transaction_returning_status do
-        revive_destroyed_dependent_records(validate)
-        run_callbacks(:revive) { set_deleted_at(nil, validate) }
+        if PermanentRecords.should_revive_parent_first?(options)
+          revival.reverse
+        else
+          revival
+        end.each { |p| p.call(options) }
+
         self
       end
     end
@@ -49,6 +53,11 @@ module PermanentRecords
     end
 
     private
+
+    def revival
+      [ ->(_validate) { revive_destroyed_dependent_records(_validate) },
+        ->(_validate) { run_callbacks(:revive) { set_deleted_at(nil, _validate) } } ]
+    end
 
     def get_deleted_record
       self.class.unscoped.find(id)
@@ -98,6 +107,18 @@ module PermanentRecords
       deleted? ? self : false
     end
 
+    def add_record_window(request, name, reflection)
+      request.unscoped.where(
+        [
+          "#{reflection.quoted_table_name}.deleted_at > ?" +
+          " AND " +
+          "#{reflection.quoted_table_name}.deleted_at < ?",
+          deleted_at - PermanentRecords.dependent_record_window,
+          deleted_at + PermanentRecords.dependent_record_window
+        ]
+      )
+    end
+
     def revive_destroyed_dependent_records(force = nil)
       self.class.reflections.select do |name, reflection|
         'destroy' == reflection.options[:dependent].to_s && reflection.klass.is_permanent?
@@ -105,15 +126,11 @@ module PermanentRecords
         cardinality = reflection.macro.to_s.gsub('has_', '').to_sym
         case cardinality
         when :many
-          records = send(name).unscoped.where(
-            [
-              "#{reflection.quoted_table_name}.deleted_at > ?" +
-              " AND " +
-              "#{reflection.quoted_table_name}.deleted_at < ?",
-              deleted_at - PermanentRecords.dependent_record_window,
-              deleted_at + PermanentRecords.dependent_record_window
-            ]
-          )
+          records = if deleted_at
+            add_record_window(send(name), name, reflection)
+          else
+            send(name)
+          end
         when :one, :belongs_to
           self.class.unscoped { records = [] << send(name) }
         end
@@ -209,6 +226,10 @@ module PermanentRecords
     else
       :force == force
     end
+  end
+
+  def self.should_revive_parent_first?(order)
+    Hash === order && true == order[:reverse]
   end
 
   def self.should_ignore_validations?(force)

--- a/spec/permanent_records/circular_sti_dependency_spec.rb
+++ b/spec/permanent_records/circular_sti_dependency_spec.rb
@@ -1,0 +1,31 @@
+require 'pry'
+
+require 'spec_helper'
+
+describe PermanentRecords do
+  let(:hole)      { dirt.hole }
+  let(:dirt)      { Dirt.create!.tap { |dirt| dirt.create_hole } }
+  let!(:location) { Location.create({name: 'location', hole: hole})  }
+  let!(:zone)     { location.zones.create({name: 'zone', parent_id: location.id, hole: hole}) }
+
+  before do
+    hole.destroy({validate: false})
+  end
+
+  describe '#revive' do
+
+    it 'should revive children properly on STI' do
+      expect(hole.reload).to     be_deleted
+      expect(dirt.reload).to     be_deleted
+      expect(location.reload).to be_deleted
+      # expect(hole.location.zones.deleted).to be_exists # STI relations isn't delete
+
+      hole.revive
+
+      expect(hole.reload).to_not     be_deleted
+      expect(dirt.reload).to_not     be_deleted
+      expect(location.reload).to_not be_deleted
+      expect(hole.location.zones.not_deleted).to be_exists
+    end
+  end
+end

--- a/spec/permanent_records/propagate_validation_flag_spec.rb
+++ b/spec/permanent_records/propagate_validation_flag_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe PermanentRecords do
+  let(:hole) { dirt.hole }
+  let(:dirt) { Dirt.create!.tap { |dirt| dirt.create_hole } }
+
+  before { hole.destroy }
+
+  describe '#revive' do
+
+    before do
+      expect(dirt).to receive(:get_deleted_record) { dirt }
+      expect(dirt).to receive(:save).with(validate: false)
+    end
+
+    it 'should propagate validation flag on dependent records' do
+      hole.revive(validate: false)
+    end
+  end
+end

--- a/spec/permanent_records/revive_parent_first_spec.rb
+++ b/spec/permanent_records/revive_parent_first_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe PermanentRecords do
+  let(:hole) { dirt.hole }
+  let!(:ant)  { hole.ants.create! }
+  let(:dirt) { Dirt.create!.tap { |dirt| dirt.create_hole } }
+
+  before { hole.destroy }
+
+  describe '#revive' do
+
+    it 'should revive parent first' do
+      hole.revive(reverse: true)
+    end
+  end
+end

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -343,8 +343,8 @@ describe PermanentRecords do
   describe 'scopes' do
 
     before {
-      3.times { Muskrat.create! }
-      6.times { Muskrat.create!.destroy }
+      3.times { Muskrat.create!({hole: hole}) }
+      6.times { Muskrat.create!({hole: hole}).destroy }
     }
 
     context '.not_deleted' do

--- a/spec/support/ant.rb
+++ b/spec/support/ant.rb
@@ -1,0 +1,18 @@
+class Ant < ActiveRecord::Base
+  belongs_to :hole
+  validates :hole, presence: true
+
+  after_revive :reactivate_ants
+
+  def add_ant ant
+    # do something like you want
+
+    # Force reload
+    Hole.not_deleted.where(id: hole.id).first.add_to_ants_cache ant
+  end
+
+  def reactivate_ants
+    # Ant.unscoped.find(destroyed_ants).each { |ant| add_ant ant }
+    Array(Ant.create).each { |ant| add_ant ant }
+  end
+end

--- a/spec/support/comment.rb
+++ b/spec/support/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ActiveRecord::Base
   belongs_to :hole
-
+  validates :hole, presence: true
   default_scope { where(:deleted_at => nil) }
 end

--- a/spec/support/difficulty.rb
+++ b/spec/support/difficulty.rb
@@ -1,6 +1,7 @@
 class Difficulty < ActiveRecord::Base
   belongs_to :hole
-
+  validates :hole, presence: true
+  
   if ActiveRecord::VERSION::STRING == '3.0.0'
     default_scope where(:deleted_at => nil)
   else

--- a/spec/support/dirt.rb
+++ b/spec/support/dirt.rb
@@ -1,4 +1,5 @@
 class Dirt < ActiveRecord::Base
   has_one :hole
+  # validates :hole, presence: true
   has_one :earthworm, :dependent => :destroy
 end

--- a/spec/support/earthworm.rb
+++ b/spec/support/earthworm.rb
@@ -1,6 +1,6 @@
 class Earthworm < ActiveRecord::Base
   belongs_to :dirt
-
+  validates :dirt, presence: true
   # Earthworms have been known to complain if they're left on their deathbeds without any dirt
   before_destroy :complain!
 

--- a/spec/support/hole.rb
+++ b/spec/support/hole.rb
@@ -7,6 +7,7 @@ class Hole < ActiveRecord::Base
   # moles are not permanent
   has_many :moles, :dependent => :destroy
 
+  has_many :ants, :dependent => :destroy
   has_one :location, :dependent => :destroy
   has_one :unused_model, :dependent => :destroy
   has_one :difficulty, :dependent => :destroy

--- a/spec/support/location.rb
+++ b/spec/support/location.rb
@@ -2,4 +2,5 @@ class Location < ActiveRecord::Base
   belongs_to :hole
   validates :hole, presence: true
   validates_uniqueness_of :name, :scope => :deleted_at
+  has_many :zones, class_name: 'Location', foreign_key: 'parent_id', dependent: :destroy
 end

--- a/spec/support/location.rb
+++ b/spec/support/location.rb
@@ -1,5 +1,5 @@
 class Location < ActiveRecord::Base
   belongs_to :hole
-
+  validates :hole, presence: true
   validates_uniqueness_of :name, :scope => :deleted_at
 end

--- a/spec/support/mole.rb
+++ b/spec/support/mole.rb
@@ -1,3 +1,4 @@
 class Mole < ActiveRecord::Base
   belongs_to :hole
+  validates :hole, presence: true
 end

--- a/spec/support/muskrat.rb
+++ b/spec/support/muskrat.rb
@@ -1,3 +1,4 @@
 class Muskrat < ActiveRecord::Base
   belongs_to :hole
+  validates :hole, presence: true
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :locations, :force => true do |t|
     t.string :name
     t.references :hole
+    t.integer :parent_id
     t.datetime :deleted_at
   end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,5 +1,11 @@
 ActiveRecord::Schema.define(:version => 1) do
 
+  create_table :ants, :force => true do |t|
+    t.column :name,         :string
+    t.column :deleted_at,   :datetime
+    t.references :hole
+  end
+
   create_table :muskrats, :force => true do |t|
     t.column :name,         :string
     t.column :deleted_at,   :datetime


### PR DESCRIPTION
When for some reasons a child object do something related to the parent on revive callback obviously the current mechanism failed, an option should be revive parent before dependent relations.

On top of https://github.com/JackDanger/permanent_records/pull/59
diff => https://github.com/joel/permanent_records/compare/182a20eee91054c38bcdc0572b01cc4c334d30b7...69499a557f82d7091a9a52496c8b4b8ed0af1a86