### PR TITLE
Not trigger ActiveRecord loading on requiring gem

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -249,4 +249,6 @@ module PermanentRecords
   end
 end
 
-ActiveRecord::Base.send :include, PermanentRecords::ActiveRecord
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.send :include, PermanentRecords::ActiveRecord
+end


### PR DESCRIPTION
When this gem required ActiveRecord::Base triggered to load and make connections to database. This should not be due to (for example) failing assets:precomplie in Heroku (https://devcenter.heroku.com/articles/rails-asset-pipeline#troubleshooting), where build phase and run phase are separated and database is not available on build phase.