### PR TITLE
Fixes a bug for single table inheritence

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -73,12 +73,7 @@ module PermanentRecords
     end
 
     def get_deleted_record # rubocop:disable Style/AccessorMethodName
-      # Looking for parent on STI case
-      if respond_to?(:parent_id) && parent_id.present?
-        self.class.unscoped.find(parent_id)
-      else
-        self.class.unscoped.find(id)
-      end
+      self.class.unscoped.find(id)
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/spec/permanent_records/circular_sti_dependency_spec.rb
+++ b/spec/permanent_records/circular_sti_dependency_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 
 describe PermanentRecords do
-  let(:hole)      { dirt.hole }
-  let(:dirt)      { Dirt.create!.tap(&:create_hole) }
-  let!(:location) { Location.create(name: 'location', hole: hole) }
-  let!(:zone)     do
-    location.zones.create(name: 'zone', parent_id: location.id, hole: hole)
+  let(:hole)     { dirt.hole }
+  let(:dirt)     { Dirt.create!.tap(&:create_hole) }
+  let(:location) { Location.create(name: 'location', hole: hole) }
+  let!(:zone) do
+    location.zones.create name: 'zone', parent_id: location.id
   end
 
   before do
-    hole.destroy(validate: false)
+    hole.destroy
   end
 
   describe '#revive' do
@@ -17,15 +17,12 @@ describe PermanentRecords do
       expect(hole.reload).to     be_deleted
       expect(dirt.reload).to     be_deleted
       expect(location.reload).to be_deleted
-      ## STI relations isn't delete
-      # expect(hole.location.zones.deleted).to be_exists
-
+      expect(zone.reload).to     be_deleted
       hole.revive
-
       expect(hole.reload).to_not     be_deleted
       expect(dirt.reload).to_not     be_deleted
       expect(location.reload).to_not be_deleted
-      expect(hole.location.zones.not_deleted).to be_exists
+      expect(zone.reload).to_not     be_deleted
     end
   end
 end

--- a/spec/support/location.rb
+++ b/spec/support/location.rb
@@ -1,9 +1,15 @@
 class Location < ActiveRecord::Base
   belongs_to :hole
-  validates :hole, presence: true
+  validates :hole, presence: true, unless: :zone?
   validates_uniqueness_of :name, scope: :deleted_at
   has_many :zones,
            class_name: 'Location',
            foreign_key: 'parent_id',
            dependent: :destroy
+
+  private
+
+  def zone?
+    parent_id.present?
+  end
 end


### PR DESCRIPTION
Those lines replaced all the attributes of a record during a soft destroy:
* https://github.com/JackDanger/permanent_records/blob/b681ccf1ec2bc12e5004d14e792e3b193a08acb7/lib/permanent_records.rb#L87
* https://github.com/JackDanger/permanent_records/blob/b681ccf1ec2bc12e5004d14e792e3b193a08acb7/lib/permanent_records.rb#L78
* https://github.com/JackDanger/permanent_records/blob/b681ccf1ec2bc12e5004d14e792e3b193a08acb7/lib/permanent_records.rb#L99
Example:
```ruby
class Branche < ActiveRecord::Base
  include ActiveRecord::SoftDestroyable
  has_many :sub_branches, foreign_key: 'parent_id', class_name: 'Branche'
  belongs_to :main_branche, foreign_key: 'parent_id', class_name: 'Branche'
end
main_branche = Branche.create
main_branche.id # => 1
sub_branche = Branche.create parent_id: main_branche.id
sub_branche.id # => 2
sub_branche.destroy!
sub_branche.id # => ! 1 in place of 2
 # because the instance attributes have been replaced.
```

The spec was a false positive because the relation between hole and
location is `has_one` not `has_many`:
* https://github.com/JackDanger/permanent_records/blob/b681ccf1ec2bc12e5004d14e792e3b193a08acb7/spec/permanent_records/circular_sti_dependency_spec.rb#L6-L8
* https://github.com/JackDanger/permanent_records/blob/b681ccf1ec2bc12e5004d14e792e3b193a08acb7/spec/support/hole.rb#L12