### PR TITLE
remove deprecations

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -166,10 +166,8 @@ module PermanentRecords
         end.to_a.flatten.compact.each do |dependent|
           dependent.revive(force)
         end
-
-        # and update the reflection cache
-        send(name, :reload)
       end
+      reload
     end
 
     def attempt_notifying_observers(callback)

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -134,7 +134,7 @@ describe PermanentRecords do
 
             context 'when error occurs' do
               before do
-                Difficulty.any_instance.stub(:destroy).and_return(false)
+                allow_any_instance_of(Difficulty).to receive(:destroy) { throw(:abort) }
               end
               it('') { expect { subject }.not_to change { Muskrat.count } }
               it('') { expect { subject }.not_to change { Comment.count } }
@@ -151,7 +151,7 @@ describe PermanentRecords do
             before { Hole.any_instance.stub(:valid?).and_return(false) }
             it('does not mark records as deleted') do
               expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
-              expect(record.location(true)).not_to be_deleted
+              expect(record.reload.location).not_to be_deleted
             end
           end
 
@@ -162,7 +162,7 @@ describe PermanentRecords do
 
             context 'when error occurs' do
               before do
-                Difficulty.any_instance.stub(:destroy).and_return(false)
+                allow_any_instance_of(Difficulty).to receive(:destroy) { throw(:abort) }
               end
               it('') { expect { subject }.not_to change { Muskrat.count } }
               it('') { expect { subject }.not_to change { Location.count } }
@@ -179,7 +179,7 @@ describe PermanentRecords do
             before { Hole.any_instance.stub(:valid?).and_return(false) }
             it 'does not mark records as deleted' do
               expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
-              expect(record.dirt(true)).not_to be_deleted
+              expect(record.dirt).not_to be_deleted
             end
           end
 
@@ -189,7 +189,7 @@ describe PermanentRecords do
 
             context 'when error occurs' do
               before do
-                Difficulty.any_instance.stub(:destroy).and_return(false)
+                allow_any_instance_of(Difficulty).to receive(:destroy) { throw(:abort) }
               end
               it('') { expect { subject }.not_to change { Dirt.count } }
             end
@@ -297,7 +297,7 @@ describe PermanentRecords do
             before { Hole.any_instance.stub(:valid?).and_return(false) }
             it('does not mark records as deleted') do
               expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
-              expect(record.location(true)).to be_deleted
+              expect(record.location).to be_deleted
             end
           end
         end
@@ -311,7 +311,7 @@ describe PermanentRecords do
             before { Hole.any_instance.stub(:valid?).and_return(false) }
             it 'does not revive them' do
               expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
-              expect(record.dirt(true)).to be_deleted
+              expect(record.dirt).to be_deleted
             end
           end
         end

--- a/spec/support/hole.rb
+++ b/spec/support/hole.rb
@@ -26,6 +26,7 @@ class Hole < ActiveRecord::Base
   private
 
   def check_youre_not_in_the_hole
-    !youre_in_the_hole
+    return true unless youre_in_the_hole
+    throw :abort
   end
 end


### PR DESCRIPTION
Removing following deprecations  : 

```DEPRECATION WARNING: Passing an argument to force an association to reload is now deprecated and will be removed in Rails 5.1. Please call `reload` on the parent object instead.```

And 

```DEPRECATION WARNING: Returning `false` in Active Record and Active Model callbacks will not implicitly halt a callback chain in Rails 5.1. To explicitly halt the callback chain, please use `throw :abort` instead.```