### PR TITLE
Fix NoMethodError for HABTM associations

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -107,7 +107,7 @@ module PermanentRecords
 
     def each_counter_cache
       _reflections.each do |name, reflection|
-        association = send(name.to_sym)
+        association = respond_to?(name.to_sym) ? send(name.to_sym) : nil
         next if association.nil?
         next unless reflection.belongs_to? && reflection.counter_cache_column
 

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -11,6 +11,7 @@ describe PermanentRecords do
   let!(:difficulty) { hole.create_difficulty                }
   let!(:comments)   { 2.times.map { hole.comments.create! } }
   let!(:kitty)      { Kitty.create!                         }
+  let!(:meerkat)    { Meerkat.create!(holes: [hole])        }
 
   describe '#destroy' do
     let(:record)       { hole    }
@@ -222,6 +223,28 @@ describe PermanentRecords do
         end
       end
     end
+
+    context 'with habtm association' do
+      it 'does not remove the associated records' do
+        expect { subject }.not_to change { Meerkat.count }
+      end
+
+      it 'does not remove the entry from the join table' do
+        expect { subject }.not_to change { meerkat.holes.count }
+      end
+
+      context 'with force argument set to truthy' do
+        let(:should_force) { :force }
+
+        it 'does not remove the associated records' do
+          expect { subject }.not_to change { Meerkat.count }
+        end
+
+        it 'removes the entry from the join table' do
+          expect { subject }.to change { meerkat.holes.count }.by(-1)
+        end
+      end
+    end
   end
 
   describe '#revive' do
@@ -343,6 +366,12 @@ describe PermanentRecords do
             expect(Difficulty.find_by_id(subject.difficulty.id)).to eq(difficulty)
           end
         end
+      end
+    end
+
+    context 'with habtm association' do
+      it 'does not change entries from the join table' do
+        expect { subject }.not_to change { meerkat.holes.count }
       end
     end
   end

--- a/spec/support/hole.rb
+++ b/spec/support/hole.rb
@@ -13,6 +13,7 @@ class Hole < ActiveRecord::Base
   has_one :unused_model, dependent: :destroy
   has_one :difficulty, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_and_belongs_to_many :meerkats
 
   has_many :poly_ants, class_name: 'Ant', dependent: :destroy, as: :any_hole
 

--- a/spec/support/meerkat.rb
+++ b/spec/support/meerkat.rb
@@ -1,0 +1,3 @@
+class Meerkat < ActiveRecord::Base
+  has_and_belongs_to_many :holes
+end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -56,6 +56,15 @@ ActiveRecord::Schema.define(version: 1) do
     t.datetime :deleted_at
   end
 
+  create_table :holes_meerkats, force: true do |t|
+    t.references :hole
+    t.references :meerkat
+  end
+
+  create_table :meerkats, force: true do |t|
+    t.string :name
+  end
+
   create_table :dirts, force: true do |t|
     t.string :color
     t.datetime :deleted_at


### PR DESCRIPTION
Fixes the NoMethodError in `each_counter_cache` which occurred as soon as you had a HABTM association. This should fix #94. 

Added a HABTM association to the tests. Existing counter cache tests stay green. 

Side note: This also might be an alternative to PR #90 (@joel if you meant the same with `_reflections` giving "wrong associations"). 

/cc @drakmail @JackDanger 