### PR TITLE
Disable validations on destroy

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -91,7 +91,7 @@ module PermanentRecords
         # ActiveRecord::RecordInvalid error will be raised if the record isn't
         # valid. (This prevents reviving records that disregard validation
         # constraints,)
-        if PermanentRecords.should_ignore_validations?(force)
+        if PermanentRecords.should_ignore_validations?(force) || value.present?
           record.save(validate: false)
         else
           record.save!

--- a/permanent_records.gemspec
+++ b/permanent_records.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '>= 3.5.0'
   s.add_development_dependency 'rubocop', '~> 0.68.0' # freeze to ensure ruby 2.2 compatibility
   s.add_development_dependency 'rubocop-performance'
-  s.add_development_dependency 'sqlite3', '~> 1.3.13' # freeze to ensure specs are working
+  s.add_development_dependency 'sqlite3', '~> 1.4' # freeze to ensure specs are working
 end

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -60,8 +60,8 @@ describe PermanentRecords do
       before do
         allow_any_instance_of(Hole).to receive(:valid?).and_return(false)
       end
-      it 'raises' do
-        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      it 'does not raise' do
+        expect { subject }.not_to raise_error(ActiveRecord::RecordInvalid)
       end
 
       context 'with validation opt-out' do
@@ -122,9 +122,9 @@ describe PermanentRecords do
 
           context 'when error occurs' do
             before { allow_any_instance_of(Hole).to receive(:valid?).and_return(false) }
-            it 'does not mark records as deleted' do
-              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
-              expect(record.muskrats.not_deleted.count).to eq(1)
+            it 'marks records as deleted' do
+              expect { subject }.not_to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.muskrats.not_deleted.count).to eq(0)
             end
           end
 
@@ -150,9 +150,9 @@ describe PermanentRecords do
 
           context 'when error occurs' do
             before { allow_any_instance_of(Hole).to receive(:valid?).and_return(false) }
-            it('does not mark records as deleted') do
-              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
-              expect(record.reload.location).not_to be_deleted
+            it('marks records as deleted') do
+              expect { subject }.not_to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.reload.location).to be_deleted
             end
           end
 
@@ -178,9 +178,9 @@ describe PermanentRecords do
 
           context 'when error occurs' do
             before { allow_any_instance_of(Hole).to receive(:valid?).and_return(false) }
-            it 'does not mark records as deleted' do
-              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
-              expect(record.dirt).not_to be_deleted
+            it 'marks records as deleted' do
+              expect { subject }.not_to raise_error(ActiveRecord::RecordInvalid)
+              expect(record.dirt).to be_deleted
             end
           end
 

--- a/spec/permanent_records_spec.rb
+++ b/spec/permanent_records_spec.rb
@@ -293,7 +293,7 @@ describe PermanentRecords do
         end
 
         context 'that were deleted previously' do
-          before { muskrat.update_attributes! deleted_at: 2.minutes.ago }
+          before { muskrat.update_attribute :deleted_at, 2.minutes.ago }
           it 'does not restore' do
             expect { subject }.to_not change(muskrat, :deleted?)
           end


### PR DESCRIPTION
Hi there!

I'm currently working on a project using `permanent_records`. Unfortunately we have invalid records in the database. These cannot be soft-deleted because `permanent_records` does not pass validation options to dependent records (https://github.com/JackDanger/permanent_records/issues/61).

It is possible to use `record.destroy(validate: false)` to ignore validations on the current record. But any associated record does not receive the options.

I dig a bit through the code and I guess it will be quite difficult to pass those options. In most cases `ActiveRecord` is calling `destroy`. Do you already have a plan how to solve that?

However, while digging, I asked myself why the record is validated in the first place. I understand the reason for validation when reviving a record. But when soft-deleting a record, only the `deleted_at` attribute is set. Is it really necessary to validate that? Because the records are deleted, I don't necessarily mind that they are invalid.

## Proposed changes

- Fixed SQLite dependency and fixed an issue in the spec
- Change not to validate when soft-deleting a record

Thank you for having a look!