### PR TITLE
Check If Record Has DeletedAt Column

### DIFF
--- a/lib/permanent_records.rb
+++ b/lib/permanent_records.rb
@@ -215,7 +215,7 @@ module PermanentRecords
           record = klass.unscoped.where(klass.primary_key => id).first
           next unless record
 
-          record.deleted_at = nil
+          record.deleted_at = nil if record.respond_to?(:deleted_at)
           record.destroy(:force)
         end
       end

--- a/spec/support/bed.rb
+++ b/spec/support/bed.rb
@@ -1,0 +1,3 @@
+class Bed < ActiveRecord::Base
+  has_one :kitty
+end

--- a/spec/support/kitty.rb
+++ b/spec/support/kitty.rb
@@ -1,2 +1,3 @@
 class Kitty < ActiveRecord::Base
+  has_and_belongs_to_many :beds, dependent: :destroy
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -13,8 +13,18 @@ ActiveRecord::Schema.define(version: 1) do
     t.references :hole
   end
 
+  create_table :beds, force: true do |t|
+    t.column :name, :string
+  end
+
   create_table :kitties, force: true do |t|
     t.column :name, :string
+    t.references :bed
+  end
+
+  create_table :beds_kitties, force: true do |t|
+    t.references :kitty
+    t.references :bed
   end
 
   create_table :holes, force: true do |t|


### PR DESCRIPTION
## Context
Previously, when model with has_many association without `deleted_at` column will
raise "undefined method deleted_at=" error.

With this change, it will revert to original destroy behavior when the record
does not have `deleted_at` column.